### PR TITLE
Update rubocop dependencies and fix new offense

### DIFF
--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.90.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.4.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
   spec.add_development_dependency "rubocop-rspec", "~> 1.43.1"
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.20.0"]
 end

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.13.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.89.0"
+  spec.add_development_dependency "rubocop", "~> 0.90.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.3.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
   spec.add_development_dependency "rubocop-rspec", "~> 1.43.1"

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.90.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.3.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.4.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.7.0"
   spec.add_development_dependency "rubocop-rspec", "~> 1.43.1"
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.20.0"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
-
 require "simplecov"
 SimpleCov.start do
   add_group "Main", "lib"


### PR DESCRIPTION
- Auto-update rubocop to 0.90.0
- Auto-update rubocop-packaging to 0.4.0
- Auto-update rubocop-performance to 1.8.0
- Correct Packaging/BundlerSetupInTests offense