### PR TITLE
Update RuboCop setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-rake
   - rubocop-rspec
   - rubocop-packaging
   - rubocop-performance

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,10 @@ require "rspec/core/rake_task"
 require "rake/manifest"
 
 RSpec::Core::RakeTask.new(:spec)
+
 Rake::Manifest::Task.new do |t|
   t.patterns = ["lib/**/*", "LICENSE.txt", "*.md"]
 end
 
-task default: :spec
-task build: "manifest:check"
+Rake::Task[:default].enhance :spec
+Rake::Task[:build].enhance "manifest:check"

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.14.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.11.3"
+  spec.add_development_dependency "rubocop-rake", "~> 0.5.1"
   spec.add_development_dependency "rubocop-rspec", "~> 2.3.0"
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
 end

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.12.0"
+  spec.add_development_dependency "rubocop", "~> 1.14.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.10.0"
   spec.add_development_dependency "rubocop-rspec", "~> 2.2.0"

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.14.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.10.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.11.3"
   spec.add_development_dependency "rubocop-rspec", "~> 2.2.0"
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
 end

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.14.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.11.3"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.2.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.3.0"
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
 end


### PR DESCRIPTION
- Update rubocop to version 1.14.0
- Update rubocop-performance to version 1.11.3
- Update rubocop-rspec to version 2.3.0
- Add rubocop-rake plugin and fix offenses
