### PR TITLE
Add back support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1", head]
+        ruby: [2.5, 2.6, 2.7, "3.0", "3.1", head]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
 # Be lenient with line length
 Layout/LineLength:

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Rake tasks to generate and check a manifest file"
   spec.homepage = "https://github.com/mvz/rake-manifest"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/rake-manifest"


### PR DESCRIPTION
Aruby still supports Ruby 2.5 and uses rake-manifest, so continue supporting Ruby 2.5 for now.
