### PR TITLE
Mention generate task name in failure message for check task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
 
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/lib/rake/manifest/task.rb
+++ b/lib/rake/manifest/task.rb
@@ -6,13 +6,14 @@ module Rake
   module Manifest
     # Tasks to create and check manifest file
     class Task < Rake::TaskLib
-      attr_accessor :manifest_file, :patterns
+      attr_accessor :manifest_file, :patterns, :name
 
       def initialize(name = :manifest)
         super()
 
         self.manifest_file = "Manifest.txt"
         self.patterns = ["**/*"]
+        self.name = name
 
         yield self if block_given?
 
@@ -46,7 +47,8 @@ module Rake
           if gemmable_files == manifest_files
             puts "Manifest check succesful"
           else
-            raise "Manifest check failed, try recreating the manifest"
+            raise "Manifest check failed, try recreating the manifest" \
+                  " using #{name}:generate"
           end
         end
       end

--- a/spec/rake/manifest/task_spec.rb
+++ b/spec/rake/manifest/task_spec.rb
@@ -116,7 +116,25 @@ RSpec.describe Rake::Manifest::Task do
 
       described_class.new { |c| c.patterns = ["*.rb", "FOO"] }
       expect { rake.invoke_task "manifest:check" }
-        .to raise_error "Manifest check failed, try recreating the manifest"
+        .to raise_error(/Manifest check failed, try recreating the manifest/)
+    end
+
+    it "mentions the generate task name in the failure message" do
+      File.write("Manifest.txt", "foo.rb\n")
+
+      described_class.new { |c| c.patterns = ["*.rb"] }
+      expect { rake.invoke_task "manifest:check" }
+        .to raise_error "Manifest check failed, try recreating the manifest" \
+                        " using manifest:generate"
+    end
+
+    it "uses any custom namespace for the generate task name in the failure message" do
+      File.write("Manifest.txt", "foo.rb\n")
+
+      described_class.new(:foo) { |c| c.patterns = ["*.rb"] }
+      expect { rake.invoke_task "foo:check" }
+        .to raise_error "Manifest check failed, try recreating the manifest" \
+                        " using foo:generate"
     end
   end
 end


### PR DESCRIPTION
This makes it easier for the user to immediately invoke the correct task to fix the manifest.

Fixes #71.
