### PR TITLE
Bump RuboCop dependency version and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Layout/LineContinuationLeadingSpace:
   EnforcedStyle: leading
 

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.44"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"


### PR DESCRIPTION
- Bump rubocop version so Gemspec/DevelopmentDependencies is supported
- Require development dependencies to be in the gemspec
