### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", head]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", head]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:
@@ -57,8 +57,8 @@ Lint/AssignmentInCondition:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*' # Spec describe blocks can be any size
-    - '*.gemspec' # Gem spec blocks can be any size
+    - 'spec/**/*'  # Spec describe blocks can be any size
+    - '*.gemspec'  # Gem spec blocks can be any size
 
 Performance/StartWith:
   AutoCorrect: true

--- a/rake-manifest.gemspec
+++ b/rake-manifest.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/mvz/rake-manifest"
 
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/rake-manifest"


### PR DESCRIPTION
Tooling like rubocop is dropping support for this old version of Ruby. To keep maintenance manageable, I'm dropping support as well.
